### PR TITLE
Add the assemble module for ilib-assemble to use

### DIFF
--- a/assemble.mjs
+++ b/assemble.mjs
@@ -1,0 +1,58 @@
+/*
+ * assemble.mjs - Assemble locale data for ilib-assemble
+ *
+ * Copyright © 2022 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { JSUtils, Utils } from 'ilib-common';
+import JSON5 from 'json5';
+
+let cache = {};
+
+function assemble(options) {
+    let localeData = {};
+
+    if (!options || !options.locales) return undefined;
+
+    const here = join(dirname(import.meta.url.replace(/file:\/\//, "")), "locale");
+
+    options.locales.forEach(locale => {
+        var locFiles = Utils.getLocFiles(locale, "localeinfo.json").map(file => {
+            return join(here, file);
+        });
+        let locData = {};
+        locFiles.forEach(file => {
+            if (cache[file]) {
+                locData = JSUtils.merge(locData, cache[file]);
+            } else if (existsSync(file)) {
+                const data = readFileSync(file, "utf-8");
+                const json = JSON5.parse(data);
+                locData = JSUtils.merge(locData, json);
+                cache[file] = json;
+            }
+        });
+        if (!localeData[locale]) {
+            localeData[locale] = {};
+        }
+        localeData[locale].localeinfo = JSUtils.merge(localeData[locale].localeinfo || {}, locData);
+    });
+
+    return Promise.resolve(localeData);
+}
+
+export default assemble;

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
         }
     ],
     "files": [
+        "assemble.mjs",
+        "locale",
         "src",
         "lib",
         "docs",
@@ -94,6 +96,7 @@
         "ilib-env": "^1.2.0",
         "ilib-locale": "^1.1.0",
         "ilib-localedata": "^1.0.0",
-        "ilib-localematcher": "^1.1.0"
+        "ilib-localematcher": "^1.1.0",
+        "json5": "^2.2.1"
     }
 }


### PR DESCRIPTION
This doesn't get used in the module itself, but it is loaded by ilib-assemble to gather together all of the locale data files necessary to support a list of locales.