### PR TITLE
Corrected exports, removed incorrect check, update deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,14 @@ limitations under the License.
 
 ## Release Notes
 
+### v1.0.2
+
+* Did not export the assemble.mjs file so it was not possible to assemble
+  the locale data
+* Remove the incorrect check for synchronous loading of data that is already
+  in the cache. The check is now in ilib-localedata instead.
+* Updated dependencies
+
 ### v1.0.1
 
 * This module is now a hybrid ESM/CommonJS package that works under node

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
     "name": "ilib-localeinfo",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "main": "./lib/index.js",
     "module": "./src/index.js",
     "exports": {
         ".": {
             "import": "./src/index.js",
             "require": "./lib/index.js"
-        }
+        },
+        "./assemble.mjs": "./assemble.mjs"
     },
     "description": "Encode locale info for various types of data",
     "keywords": [
@@ -119,7 +120,7 @@
         "ilib-common": "^1.1.2",
         "ilib-env": "^1.3.2",
         "ilib-locale": "^1.2.2",
-        "ilib-localedata": "^1.3.3",
+        "ilib-localedata": "^1.4.0",
         "ilib-localematcher": "^1.2.2",
         "json5": "^2.2.1"
     }

--- a/src/index.js
+++ b/src/index.js
@@ -105,18 +105,6 @@ class LocaleInfo {
             sync
         });
 
-        // ensure that we can grab the data we need
-        if (!sync && !LocaleData.checkCache(this.locale.getSpec(), "localeinfo")) {
-            const lm = new LocaleMatcher({
-                locale: this.locale.getSpec(),
-                sync: true
-            });
-            this.locale = new Locale(lm.getLikelyLocale());
-            if (!LocaleData.checkCache(this.locale.getSpec(), "localeinfo")) {
-                throw "Locale data not available";
-            }
-        }
-
         if (sync) {
             this.info = locData.loadData({
                 basename: "localeinfo",


### PR DESCRIPTION
* Did not export the assemble.mjs file so it was not possible to assemble the locale data
* Remove the incorrect check for synchronous loading of data that is already in the cache. The check is now in ilib-localedata instead.
* Updated dependencies