### PR TITLE
remove import.meta from transpiled code

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -38,9 +38,19 @@ module.exports = function(grunt) {
         babel: {
             options: {
                 sourceMap: true,
-                presets: [
-                    '@babel/preset-env'
+                presets: [[
+                    '@babel/preset-env',
+                    {
+                        targets: {
+                            node: "10",
+                            browsers: "cover 99.5%"
+                        }
+                    }
+                ]],
+                plugins: [
+                    "transform-import-meta"
                 ],
+                comments: debug,
                 compact: !debug,
                 minified: !debug
             },
@@ -48,7 +58,7 @@ module.exports = function(grunt) {
                 files: [{
                     expand: true,
                     cwd: 'src',
-                    src: ['*.js'],
+                    src: ['**/*.js'],
                     dest: 'lib/',
                     ext: '.js'
                 }]

--- a/README.md
+++ b/README.md
@@ -381,6 +381,12 @@ limitations under the License.
 
 ## Release Notes
 
+### v1.0.4
+
+* use a babel plugin to remove import.meta from the transpiled code for
+  node < v10. Previously, this prevented this package from running properly
+  on node v10
+
 ### v1.0.3
 
 * converted a static initializer into just regular const value that is

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-localeinfo",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "main": "./lib/index.js",
     "module": "./src/index.js",
     "exports": {


### PR DESCRIPTION
* use a babel plugin to remove import.meta from the transpiled code for node < v10. Previously, this prevented this package from running properly on node v10