### PR TITLE
Fix incorrect info for zh-TW, zh-MO, and zh-HK

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,11 @@ limitations under the License.
 
 ## Release Notes
 
+### v1.0.5
+
+* Fixed Taiwan info when the locale spec is "zh-TW" instead of "zh-Hant-TW".
+  Was returning the wrong info previously.
+
 ### v1.0.4
 
 * use a babel plugin to remove import.meta from the transpiled code for

--- a/locale/zh/HK/localeinfo.json
+++ b/locale/zh/HK/localeinfo.json
@@ -1,0 +1,9 @@
+{
+    "delimiter": {
+        "alternateQuotationEnd": "』",
+        "alternateQuotationStart": "『",
+        "quotationEnd": "」",
+        "quotationStart": "「"
+    },
+    "locale": "zh-Hant-HK"
+}

--- a/locale/zh/MO/localeinfo.json
+++ b/locale/zh/MO/localeinfo.json
@@ -1,0 +1,9 @@
+{
+    "delimiter": {
+        "alternateQuotationEnd": "』",
+        "alternateQuotationStart": "『",
+        "quotationEnd": "」",
+        "quotationStart": "「"
+    },
+    "locale": "zh-Hant-MO"
+}

--- a/locale/zh/TW/localeinfo.json
+++ b/locale/zh/TW/localeinfo.json
@@ -1,0 +1,9 @@
+{
+    "delimiter": {
+        "alternateQuotationEnd": "』",
+        "alternateQuotationStart": "『",
+        "quotationEnd": "」",
+        "quotationStart": "「"
+    },
+    "locale": "zh-Hant"
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-localeinfo",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "main": "./lib/index.js",
     "module": "./src/index.js",
     "exports": {

--- a/test/testLocaleInfo.js
+++ b/test/testLocaleInfo.js
@@ -625,11 +625,11 @@ export const testLocaleInfo = {
         test.done();
     },
 
-    //test cases fot zh-TW-Hant
+    //test cases for zh-Hant-TW
 
     testLocaleInfoGetDecimalSeparatorfor_zh_TW_Hant: function(test) {
         test.expect(2);
-        var info = new LocaleInfo("zh-TW-Hant");
+        var info = new LocaleInfo("zh-Hant-TW");
         test.ok(info !== null);
         test.equal(info.getDecimalSeparator(), ".");
         test.done();
@@ -637,7 +637,7 @@ export const testLocaleInfo = {
 
     testLocaleInfoGetGroupingSeparatorfor_zh_TW_Hant: function(test) {
         test.expect(2);
-        var info = new LocaleInfo("zh-TW-Hant");
+        var info = new LocaleInfo("zh-Hant-TW");
         test.ok(info !== null);
 
         test.equal(info.getGroupingSeparator(), ",");
@@ -646,7 +646,7 @@ export const testLocaleInfo = {
 
     testLocaleInfoGetPercentageFormat_zh_TW_Hant: function(test) {
         test.expect(2);
-        var info = new LocaleInfo("zh-TW-Hant");
+        var info = new LocaleInfo("zh-Hant-TW");
         test.ok(info !== null);
 
         test.equal(info.getPercentageFormat(), "{n}%");
@@ -655,7 +655,7 @@ export const testLocaleInfo = {
 
     testLocaleInfoGetCurrencyFormat_zh_TW_Hant: function(test) {
         test.expect(2);
-        var info = new LocaleInfo("zh-TW-Hant");
+        var info = new LocaleInfo("zh-Hant-TW");
         test.ok(info !== null);
 
         test.equal(info.getCurrencyFormats().common, "{s}{n}");
@@ -664,7 +664,7 @@ export const testLocaleInfo = {
 
     testLocaleInfoGetNegativeNumberFormat_zh_TW_Hant: function(test) {
         test.expect(2);
-        var info = new LocaleInfo("zh-TW-Hant");
+        var info = new LocaleInfo("zh-Hant-TW");
         test.ok(info !== null);
 
         test.equal(info.getNegativeNumberFormat(), "-{n}");
@@ -673,7 +673,7 @@ export const testLocaleInfo = {
 
     testLocaleInfoGetNegativePercentageFormat_zh_TW_Hant: function(test) {
         test.expect(2);
-        var info = new LocaleInfo("zh-TW-Hant");
+        var info = new LocaleInfo("zh-Hant-TW");
         test.ok(info !== null);
 
         test.equal(info.getNegativePercentageFormat(), "-{n}%");
@@ -682,10 +682,94 @@ export const testLocaleInfo = {
 
     testLocaleInfoGetNegativeCurrencyFormat_zh_TW_Hant: function(test) {
         test.expect(2);
-        var info = new LocaleInfo("zh-TW-Hant");
+        var info = new LocaleInfo("zh-Hant-TW");
         test.ok(info !== null);
 
         test.equal(info.getCurrencyFormats().commonNegative, "-{s}{n}");
+        test.done();
+    },
+
+    testLocaleInfoGetNegativeCurrencyFormat_zh_TW_Hant: function(test) {
+        test.expect(3);
+        var info = new LocaleInfo("zh-Hant-TW");
+        test.ok(info !== null);
+
+        test.equal(info.getDelimiterQuotationStart(), "「");
+        test.equal(info.getDelimiterQuotationEnd(), "」");
+        test.done();
+    },
+
+    //test cases for zh-TW
+
+    testLocaleInfoGetDecimalSeparatorfor_zh_TW: function(test) {
+        test.expect(2);
+        var info = new LocaleInfo("zh-TW");
+        test.ok(info !== null);
+        test.equal(info.getDecimalSeparator(), ".");
+        test.done();
+    },
+
+    testLocaleInfoGetGroupingSeparatorfor_zh_TW: function(test) {
+        test.expect(2);
+        var info = new LocaleInfo("zh-TW");
+        test.ok(info !== null);
+
+        test.equal(info.getGroupingSeparator(), ",");
+        test.done();
+    },
+
+    testLocaleInfoGetPercentageFormat_zh_TW: function(test) {
+        test.expect(2);
+        var info = new LocaleInfo("zh-TW");
+        test.ok(info !== null);
+
+        test.equal(info.getPercentageFormat(), "{n}%");
+        test.done();
+    },
+
+    testLocaleInfoGetCurrencyFormat_zh_TW: function(test) {
+        test.expect(2);
+        var info = new LocaleInfo("zh-TW");
+        test.ok(info !== null);
+
+        test.equal(info.getCurrencyFormats().common, "{s}{n}");
+        test.done();
+    },
+
+    testLocaleInfoGetNegativeNumberFormat_zh_TW: function(test) {
+        test.expect(2);
+        var info = new LocaleInfo("zh-TW");
+        test.ok(info !== null);
+
+        test.equal(info.getNegativeNumberFormat(), "-{n}");
+        test.done();
+    },
+
+    testLocaleInfoGetNegativePercentageFormat_zh_TW: function(test) {
+        test.expect(2);
+        var info = new LocaleInfo("zh-TW");
+        test.ok(info !== null);
+
+        test.equal(info.getNegativePercentageFormat(), "-{n}%");
+        test.done();
+    },
+
+    testLocaleInfoGetNegativeCurrencyFormat_zh_TW: function(test) {
+        test.expect(2);
+        var info = new LocaleInfo("zh-TW");
+        test.ok(info !== null);
+
+        test.equal(info.getCurrencyFormats().commonNegative, "-{s}{n}");
+        test.done();
+    },
+
+    testLocaleInfoGetNegativeCurrencyFormat_zh_TW: function(test) {
+        test.expect(3);
+        var info = new LocaleInfo("zh-TW");
+        test.ok(info !== null);
+
+        test.equal(info.getDelimiterQuotationStart(), "「");
+        test.equal(info.getDelimiterQuotationEnd(), "」");
         test.done();
     },
 


### PR DESCRIPTION
Missing localeinfo.json files in the zh dir means that we had the wrong quotation marks for those locales that do not specify the script "Hant".